### PR TITLE
chore: add needed stuff to build FIPS images

### DIFF
--- a/Dockerfile.fips
+++ b/Dockerfile.fips
@@ -1,0 +1,48 @@
+FROM goboring/golang:1.15b5
+
+# Software versions
+ENV BAZEL_VERSION=3.5.0
+
+WORKDIR /
+
+RUN apt-get update && \
+    apt-get -y upgrade
+
+# Install Bazel, which needs Python 3
+RUN apt-get -y remove --purge python && \
+    apt-get -y autoremove && \
+    apt-get -y install python3 python3-distutils build-essential openjdk-11-jdk zip unzip
+
+RUN ln -s /usr/bin/python3 /usr/bin/python
+
+RUN mkdir bazel && \
+    cd bazel && \
+    wget https://github.com/bazelbuild/bazel/releases/download/${BAZEL_VERSION}/bazel-${BAZEL_VERSION}-dist.zip && \
+    unzip bazel-${BAZEL_VERSION}-dist.zip && \
+    env EXTRA_BAZEL_ARGS="--host_javabase=@local_jdk//:jdk" bash ./compile.sh && \
+    mv output/bazel /usr/local/bin
+
+# Install Go stuff
+RUN go get rsc.io/goversion
+
+# Docker in Docker!
+RUN apt-get -y install apt-transport-https ca-certificates curl gnupg-agent software-properties-common
+
+RUN curl -fsSL https://download.docker.com/linux/debian/gpg | apt-key add -
+
+RUN add-apt-repository \
+   "deb [arch=amd64] https://download.docker.com/linux/debian \
+   $(lsb_release -cs) \
+   stable"
+
+RUN apt-get update && \
+    apt-get -y install docker-ce docker-ce-cli containerd.io
+
+# Cleanup
+RUN rm -rf bazel
+
+RUN rm -rf ${GOPATH}/src/*
+
+RUN apt-get clean && \
+    rm -rf /var/cache/apt/* && \
+    rm -rf /var/lib/apt/lists/*

--- a/FIPS.md
+++ b/FIPS.md
@@ -1,0 +1,61 @@
+# Building FIPS 140-2 compliant images
+
+This document briefly describes how to build `cert-manager` Docker images containing FIPS-compliant binaries. It's not a FIPS, FedRAMP nor SSL/TLS guide, you'll find lots of better documentation about those out there.
+
+## Motivation
+
+If you or your company are into FedRAMP certification like New Relic is, at some point you'll have to set up encryption in transit. That is, all data moving from one service to another across the network (even inside the same cluster and/or private network) needs to be encrypted to avoid attacks. `cert-manager` is a key component of many Kubernetes clusters, and as such it needs to be FIPS-compliant as well if our clusters are to be FedRAMP certified.
+
+Currently the FIPS 140-2 standard is required to achieve FedRAMP certification. [Here's](https://stackarmor.com/understanding-fips-140-2-requirements-for-achieving-fedramp-compliance/) a good and short read about that.
+
+Not all SSL/TLS libraries are valid to build FIPS-compliant software. In Go specifically the standard crypto library does not provide FIPS compliancy so we need to use alternatives.
+
+## BoringSSL and BoringCrypto
+
+[BoringSSL](https://boringssl.googlesource.com/boringssl/) is a fork of OpenSSL, created by Google, which provides FIPS compliancy.
+
+There's a [Golang branch](https://github.com/golang/go/tree/dev.boringcrypto) in the official Golang repository which uses BoringSSL instead of the standard crypto library. Such branch is also maintained by Google. [This read](https://github.com/golang/go/tree/dev.boringcrypto/misc/boring) is particularly relevant (especially the `Building from Docker` and the `Caveats` sections).
+
+All in all, there exists a Docker image that ships a Go distribution which uses FIPS-compliant crypto libraries. This is what we're going to use.
+
+## What we did (what's this repository for)
+
+1. Create a Docker image which will be used as builder.
+
+	To build it use the provided [Dockerfile.fips](Dockerfile.fips) file. This container will be based on `goboring/golang` (so it will contain BoringSSL libraries) and will also have [Bazel](https://bazel.build/) installed, needed to build `cert-manager` images. In this example we'll tag such container as `fips-build:release-1`:
+
+	`$ docker build -t fips-build:release-1 -f Dockerfile.fips .`
+
+1. Launch the build process inside the build container.
+
+	We'll be using the underlying Docker daemon, so we can run Docker in Docker. To do so launch the container bind mounting the host's Docker socket: `-v /var/run/docker.sock:/var/run/docker.sock`
+
+	Also mount your clone of this repo inside the container and use the mount target as working directory: `-v ${PWD}:/cert-manager -w /cert-manager`.
+
+	Finally, pass in the `DOCKER_REGISTRY` and `APP_VERSION` values as environment variables to customise your images names and tags: `-e DOCKER_REGISTRY=newrelic -e APP_VERSION=1.1-nr1`.
+
+	The final command might look like the following:
+
+	```sh
+	$ docker run \
+	-v /var/run/docker.sock:/var/run/docker.sock \
+	-v ${PWD}:/cert-manager \
+	-w /cert-manager \
+	-e DOCKER_REGISTRY=newrelic \
+	-e APP_VERSION=1.1-nr1 \
+	fips-build:release-1 \
+	make fips_images
+	```
+
+1. Profit.
+
+	You should now have your FIPS-compliant `cert-manager` images built and ready to be used.
+
+## Under the hood
+
+We've created a bunch of new `make` targets inside the `Makefile`, which in turn use some simple Bash scripts, all living in `hack/`:
+
+- `fips-params.sh` will change some build settings so `CGO` can be used. This is needed so the binaries are compiled using the BoringSSL libraries. You can use `goversion` (bundled in the builder Docker image) to check that.
+- `fips-tags.sh` will retag the built images, removing an `-amd64` suffix.
+- `fips-push.sh` will just push all built images up to the specified Docker registry.
+

--- a/hack/fips-params.sh
+++ b/hack/fips-params.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+# Use the host's Go installation
+# This expects the compilation to happen in a goboring/golang container
+sed -i 's/go_version\ =\ ".*"/go_version\ =\ "host"/' WORKSPACE
+
+# Change 'pure' parameter for all Go binaries
+# This enables CGO
+for CMD in $(ls cmd/); do
+    sed -i 's/pure\ =\ "on"/pure\ =\ "off"/' cmd/${CMD}/BUILD.bazel
+done
+
+# Change compile image to distroless/base
+# We're using CGO, a static image won't work
+sed -i 's/repository\ =\ "distroless\/static"/repository\ =\ "distroless\/base"/' build/images.bzl
+sed -i '/digest\ =\ ".*$/d' build/images.bzl

--- a/hack/fips-params.sh
+++ b/hack/fips-params.sh
@@ -1,4 +1,8 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
+# +skip_license_check
+
+set -o errexit
 
 # Use the host's Go installation
 # This expects the compilation to happen in a goboring/golang container

--- a/hack/fips-push.sh
+++ b/hack/fips-push.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+REGISTRY=${1}
+TAG=${2}
+
+# Push images
+for COMPONENT in $(ls cmd/); do
+    if [[ $(docker images -q ${REGISTRY}/cert-manager-${COMPONENT}:${TAG}) != "" ]]; then
+        docker push ${REGISTRY}/cert-manager-${COMPONENT}:${TAG}
+    fi
+done

--- a/hack/fips-push.sh
+++ b/hack/fips-push.sh
@@ -1,4 +1,8 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
+# +skip_license_check
+
+set -o errexit
 
 REGISTRY=${1}
 TAG=${2}

--- a/hack/fips-tags.sh
+++ b/hack/fips-tags.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+REGISTRY=${1}
+TAG=${2}
+
+# Remove arch from image names
+echo "Removing '-amd64' suffix from image names..."
+for COMPONENT in $(ls cmd/); do
+    if [[ $(docker images -q ${REGISTRY}/cert-manager-${COMPONENT}-amd64:${TAG}) != "" ]]; then
+        echo "Tagging ${REGISTRY}/cert-manager-${COMPONENT}-amd64:${TAG} as ${REGISTRY}/cert-manager-${COMPONENT}:${TAG}"
+        docker tag ${REGISTRY}/cert-manager-${COMPONENT}-amd64:${TAG} ${REGISTRY}/cert-manager-${COMPONENT}:${TAG}
+        docker rmi ${REGISTRY}/cert-manager-${COMPONENT}-amd64:${TAG}
+    fi
+done

--- a/hack/fips-tags.sh
+++ b/hack/fips-tags.sh
@@ -1,4 +1,8 @@
-#!/bin/bash
+#!/usr/bin/env bash
+
+# +skip_license_check
+
+set -o errexit
 
 REGISTRY=${1}
 TAG=${2}


### PR DESCRIPTION
This adds our customizations to build cert-manager images using FIPS-compliant binaries.